### PR TITLE
Create Badges#available

### DIFF
--- a/lib/google/directory/schema.rb
+++ b/lib/google/directory/schema.rb
@@ -24,6 +24,11 @@ module Google
                         parameters: default_query.merge(schemaKey: key))
       end
 
+      def get(key)
+        client.execute!(api_method: schema_api.get,
+                        parameters: default_query.merge(schemaKey: key)).data
+      end
+
       private
 
       def schema_api

--- a/lib/google/directory/user/badges.rb
+++ b/lib/google/directory/user/badges.rb
@@ -2,6 +2,11 @@ module Google
   module Directory
     class User < BaseApi
       class Badges < BaseApi
+        def initialize(client = nil, schema_api = nil)
+          super(client)
+          @schema_api = schema_api
+        end
+
         # Update a users badges
         #
         # @param user_key [String] Can be the user's primary email address, alias email address, or unique user ID.
@@ -13,6 +18,19 @@ module Google
           client.execute!(api_method: directory_api.users.patch,
             body_object: body,
             parameters: default_query.merge(userKey: user_key))
+        end
+
+        # Update a users badges
+        #
+        # Returns the list of available badges
+        def available
+          schema_api.get("badges").fields.map(&:field_name)
+        end
+
+        private
+
+        def schema_api
+          @schema_api ||= Google::Directory::Schema.new(client)
         end
       end
     end

--- a/lib/google/wrapper/version.rb
+++ b/lib/google/wrapper/version.rb
@@ -1,5 +1,5 @@
 module Google
   module Wrapper
-    VERSION = "0.0.3"
+    VERSION = "0.0.5"
   end
 end

--- a/spec/google/directory/schema_spec.rb
+++ b/spec/google/directory/schema_spec.rb
@@ -42,6 +42,15 @@ module Google::Directory
       ])
       expect(parameters).to eql({ customer: "my_customer", customerId: "1234" })
     end
+
+    it "proxies get to a google api client" do
+      result = schema_api.get("badges")
+      api_method = result.api_method
+      parameters = result.parameters
+
+      expect(api_method.name).to eql("admin.schemas.get")
+      expect(parameters).to eql({ customer: "my_customer", customerId: "1234", schemaKey: "badges" })
+    end
   end
 
   describe Schema::Field do

--- a/spec/google/directory/user/badges_spec.rb
+++ b/spec/google/directory/user/badges_spec.rb
@@ -33,5 +33,20 @@ module Google::Directory
         userKey: "john.bohn@alphasights.com"
       })
     end
+
+    it "returns the name of available badges from google schema api" do
+      schema_api = double(Google::Directory::Schema)
+      badgeFields = [
+        double(field_name: "foo"),
+        double(field_name: "bar"),
+      ]
+
+      schema_double = double({fields: badgeFields})
+      expect(schema_api).to receive(:get).with("badges").and_return(schema_double)
+
+      badges_api = described_class.new(client_spy, schema_api)
+
+      expect(badges_api.available).to eql(%w(foo bar))
+    end
   end
 end


### PR DESCRIPTION
This allows us to fix an error on syncing badges (https://www.pivotaltracker.com/story/show/115786751). We need it because we need to see what badges Google has and only update those because there's a strict schema Google side and if we try to send badges that are local but aren't there (in this case when badges are remove pistachio side but never migrated out of the database), it'll raise an error with google because it says that field doesn't exist.